### PR TITLE
accept arguments with no type

### DIFF
--- a/src/ArtisanJob.php
+++ b/src/ArtisanJob.php
@@ -81,7 +81,7 @@ class ArtisanJob
                     throw RequiredOptionMissing::make($this->getCommandName(), $parameterName);
                 }
 
-                $parameterType = $parameter->getType()->getName();
+                $parameterType = $parameter->getType()?->getName();
 
                 if (is_a($parameterType, Model::class, true)) {
                     $model = $parameterType::find($value);

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -7,6 +7,7 @@ use Spatie\ArtisanDispatchable\ArtisanJobRepository;
 use Spatie\ArtisanDispatchable\Exceptions\ModelNotFound;
 use Spatie\ArtisanDispatchable\Exceptions\RequiredOptionMissing;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
+use Tests\TestClasses\Jobs\IntegrationTestJobs\ArgumentWithoutTypeTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\BasicTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\BooleanTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\CustomNameTestJob;
@@ -136,5 +137,16 @@ class IntegrationTest extends TestCase
             ->assertExitCode(0);
 
         $this->assertJobHandled(CustomNameTestJob::class);
+    }
+
+    /** @test */
+    public function it_can_accept_an_argument_without_a_type()
+    {
+        $this
+            ->artisan('argument-without-type-test --testArg=1234')
+            ->assertExitCode(0);
+
+        $this->assertJobHandled(ArgumentWithoutTypeTestJob::class);
+        $this->assertEquals(1234, self::$handledJob->testArg);
     }
 }

--- a/tests/TestClasses/Jobs/IntegrationTestJobs/ArgumentWithoutTypeTestJob.php
+++ b/tests/TestClasses/Jobs/IntegrationTestJobs/ArgumentWithoutTypeTestJob.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Tests\TestClasses\Jobs\IntegrationTestJobs;
+
+use Tests\TestClasses\Jobs\BaseTestJob;
+
+class ArgumentWithoutTypeTestJob extends BaseTestJob
+{
+    public function __construct(
+        public $testArg
+    ) {
+    }
+}


### PR DESCRIPTION
This PR takes care of arguments without types. E.g.
```
class ProcessPodcast implements ShouldQueue, ArtisanDispatchable
{
    public function __construct($podcast) {
         ...
    }
}
```