### PR TITLE
Allow users to specify a custom command name prefix

### DIFF
--- a/config/artisan-dispatchable.php
+++ b/config/artisan-dispatchable.php
@@ -22,4 +22,9 @@ return [
      * Here you can specify where the cache should be stored.
      */
     'cache_file' => storage_path('app/artisan-dispatchable/artisan-dispatchable-jobs.php'),
+
+    /**
+     * This value specifies the prefix of the command name, when no custom name is set.
+     */
+    'command_name_prefix' => null,
 ];

--- a/src/ArtisanJob.php
+++ b/src/ArtisanJob.php
@@ -5,6 +5,7 @@ namespace Spatie\ArtisanDispatchable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Console\ClosureCommand;
 use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
 use ReflectionClass;
 use ReflectionParameter;
 use Spatie\ArtisanDispatchable\Exceptions\ModelNotFound;
@@ -29,7 +30,10 @@ class ArtisanJob
 
         $shortClassName = class_basename($this->jobClassName);
 
-        return Str::of($shortClassName)->kebab()->beforeLast('-job');
+        return Str::of($shortClassName)
+            ->kebab()
+            ->beforeLast('-job')
+            ->when(config('artisan-dispatchable.command_name_prefix'), fn (Stringable $str, string $prefix) => $str->prepend($prefix . ':'));
     }
 
     public function getCommandDescription(): string

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -149,4 +149,38 @@ class IntegrationTest extends TestCase
         $this->assertJobHandled(ArgumentWithoutTypeTestJob::class);
         $this->assertEquals(1234, self::$handledJob->argumentWithoutType);
     }
+
+    /** @test */
+    public function it_can_have_a_custom_prefix()
+    {
+        config()->set('artisan-dispatchable.command_name_prefix', 'job');
+        config()->set(
+            'artisan-dispatchable.auto_discover_dispatchable_jobs',
+            [$this->getJobsDirectory('IntegrationTestJobs')]
+        );
+        (new ArtisanJobRepository())->registerAll();
+
+        $this
+            ->artisan('job:basic-test')
+            ->assertExitCode(0);
+
+        $this->assertJobHandled(BasicTestJob::class);
+    }
+
+    /** @test */
+    public function it_can_have_a_custom_prefix_and_respect_a_custom_name()
+    {
+        config()->set('artisan-dispatchable.command_name_prefix', 'job');
+        config()->set(
+            'artisan-dispatchable.auto_discover_dispatchable_jobs',
+            [$this->getJobsDirectory('IntegrationTestJobs')]
+        );
+        (new ArtisanJobRepository())->registerAll();
+
+        $this
+            ->artisan("custom:name")
+            ->assertExitCode(0);
+
+        $this->assertJobHandled(CustomNameTestJob::class);
+    }
 }


### PR DESCRIPTION
This allows a user to specify a custom command prefix, such as 'job', making the generated commands distinct from the "normal" commands plus also allowing one to list those commands via for example:
```shell
php artisan list job
```
This command would list all commands under the job namespace giving an overview what commands / jobs are available
