### PR TITLE
support spatie/phpunit-snapshot-assertions v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "illuminate/console": "^8.46|^9.0|^10.0",
         "illuminate/contracts": "^8.46|^9.0|^10.0",
         "spatie/laravel-package-tools": "^1.4.3",
-        "spatie/phpunit-snapshot-assertions": "^4.2"
+        "spatie/phpunit-snapshot-assertions": "^4.2|^5.0"
     },
     "require-dev": {
         "brianium/paratest": "^6.2",


### PR DESCRIPTION
From the changelogs of both projects it appears that this should be compatible. I started a new Laravel v10 project and was unable to add `spatie/laravel-artisan-dispatchable` despite supporting Laravel 10 due to the  PHP Unit version requirement in `spatie/phpunit-snapshot-assertions` v4