### PR TITLE
Allow Optional Parameters

### DIFF
--- a/src/ArtisanJob.php
+++ b/src/ArtisanJob.php
@@ -83,6 +83,10 @@ class ArtisanJob
                 $value = $command->option($parameterName);
 
                 if (is_null($value)) {
+                    if ($parameter->isDefaultValueAvailable()) {
+                        return $parameter->getDefaultValue();
+                    }
+
                     throw RequiredOptionMissing::make($this->getCommandName(), $parameterName);
                 }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -11,6 +11,7 @@ use Tests\TestClasses\Jobs\IntegrationTestJobs\BooleanTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\CustomNameTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\IntegerTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\ModelTestJob;
+use Tests\TestClasses\Jobs\IntegrationTestJobs\OptionalParameterTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\StringTestJob;
 use Tests\TestClasses\Models\TestModel;
 
@@ -67,6 +68,13 @@ it('will throw an exception if a model cannot be found', function () {
 it('will throw an exception if a required parameter is not passed')
     ->tap(fn () => $this->artisan("model-test"))
     ->throws(RequiredOptionMissing::class);
+
+it('can have optional parameters', function () {
+    $this->artisan("optional-parameter-test")
+        ->assertExitCode(0);
+
+    $this->assertJobHandled(OptionalParameterTestJob::class);
+});
 
 it('can handle string options', function () {
     $this

--- a/tests/TestClasses/Jobs/IntegrationTestJobs/OptionalParameterTestJob.php
+++ b/tests/TestClasses/Jobs/IntegrationTestJobs/OptionalParameterTestJob.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\TestClasses\Jobs\IntegrationTestJobs;
+
+use Tests\TestClasses\Jobs\BaseTestJob;
+
+class OptionalParameterTestJob extends BaseTestJob
+{
+    public function __construct(public int $number = 1)
+    {
+    }
+}


### PR DESCRIPTION
Sometimes, I have default parameters in the constructor of a job.  If no option is passed to the command, currently this causes an exception to be thrown.  

This PR adds a check before throwing this exception, to see if there is a default parameter value available, and returns it if so.