### PR TITLE
Fix command descriptions

### DIFF
--- a/src/ArtisanJobRepository.php
+++ b/src/ArtisanJobRepository.php
@@ -17,7 +17,7 @@ class ArtisanJobRepository
                 Artisan::command($discoveredArtisanJob->commandSignature, function () use ($artisanJob) {
                     /** @var $this ClosureCommand */
                     $artisanJob->handleCommand($this);
-                });
+                })->purpose($discoveredArtisanJob->commandDescription);
             });
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Bus;
 use Spatie\ArtisanDispatchable\ArtisanJobRepository;
 use Spatie\ArtisanDispatchable\Exceptions\ModelNotFound;
 use Spatie\ArtisanDispatchable\Exceptions\RequiredOptionMissing;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\CommandNotFoundException;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\ArgumentWithoutTypeTestJob;
 use Tests\TestClasses\Jobs\IntegrationTestJobs\BasicTestJob;
@@ -113,6 +115,15 @@ it('can use handle a custom name', function () {
         ->assertExitCode(0);
 
     $this->assertJobHandled(CustomNameTestJob::class);
+});
+
+it('can handle a custom description', function () {
+    expect(collect(Artisan::all()))
+        ->contains(
+            fn (Command $command) => $command->getName() === 'custom-description-test'
+                && $command->getDescription() === 'This a custom description'
+        )
+        ->toBeTrue();
 });
 
 it('can accept an argument without a type', function () {

--- a/tests/TestClasses/Jobs/IntegrationTestJobs/CustomDescriptionTestJob.php
+++ b/tests/TestClasses/Jobs/IntegrationTestJobs/CustomDescriptionTestJob.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests\TestClasses\Jobs\IntegrationTestJobs;
+
+use Tests\TestClasses\Jobs\BaseTestJob;
+
+class CustomDescriptionTestJob extends BaseTestJob
+{
+    public $artisanDescription = 'This a custom description';
+}


### PR DESCRIPTION
This PR fixes the ability to use the `$artisanDescription` property to set the description of the command.

By the default the description `Execute job App\Jobs\ProcessPodcast` is used ([defined here](https://github.com/spatie/laravel-artisan-dispatchable/blob/main/src/ArtisanJob.php#L42))

Fixes #12